### PR TITLE
Update Dockerfile and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+networkQuality

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 # Run with: docker run goresp
 
-FROM golang:1.17.8-alpine3.15
+FROM golang:1.18.1-alpine3.15
 
 RUN mkdir /goresponsiveness
 ADD . /goresponsiveness

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # Build with: docker build -t goresp .
 
-# Run with: docker run goresp
+# Run with: docker run --rm goresp
 
 FROM golang:1.18.3-alpine3.16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 # Run with: docker run goresp
 
-FROM golang:1.18.1-alpine3.15
+FROM golang:1.18.3-alpine3.16
 
 RUN mkdir /goresponsiveness
 ADD . /goresponsiveness

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ You can also test against the Apple infrastructure using:
 $ ./networkQuality --config mensura.cdn-apple.com --port 443 --path /api/v1/gm/config
 ```
 
+## Dockerfile
+
+This repo contains a Dockerfile for running the binary so you
+don't have to install any languages or build tools.
+To use it:
+
+```
+# build the container
+docker build -t goresp .   
+
+# run the RPM test
+docker run --rm goresp     
+
+# run the RPM test with full options, testing against Apple infrastructure
+docker run --rm goresp --config mensura.cdn-apple.com --port 443 --path /api/v1/gm/config --debug
+```
+
 ## Contributing
 
 We *love* contributions. Before submitting a patch, format your code with `go fmt`.


### PR DESCRIPTION
I've had these little changes queued up locally and neglected to create a PR.

- Update Dockerfile for golang 1.18.3 and Alpine 3.16
- Include binary of `networkQuality` in the .gitignore file