### PR TITLE
Disable extendedstats for Darwin builds

### DIFF
--- a/extendedstats/other.go
+++ b/extendedstats/other.go
@@ -1,5 +1,5 @@
-//go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd
-// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
+//go:build !dragonfly && !freebsd && !linux && !netbsd && !openbsd
+// +build !dragonfly,!freebsd,!linux,!netbsd,!openbsd
 
 package extendedstats
 

--- a/extendedstats/unix.go
+++ b/extendedstats/unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
+//go:build dragonfly || freebsd || linux || netbsd || openbsd
+// +build  dragonfly freebsd linux netbsd openbsd
 
 package extendedstats
 

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/network-quality/goresponsiveness
 
 go 1.18
 
-require golang.org/x/net v0.0.0-20220225172249-27dd8689420f
-
 require (
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 )
+
+require golang.org/x/text v0.3.7 // indirect


### PR DESCRIPTION
The [`golang.org/x/sys/unix`](https://pkg.go.dev/golang.org/x/sys/unix?GOOS=darwin) package does not have a `unix.TCPInfo` type on Darwin (macOS), so the `github.com/network-quality/goresponsiveness/extendedstats` package will not build for darwin systems. This can be easily replicated on non-Darwin systems with `$ GOOS=darwin GOARCH=arm64 go install github.com/network-quality/goresponsiveness@latest`. 

An extremely cursory search turned up the Darwin `getsockopt(sock, IPPROTO_TCP, TCP_CONNECTION_INFO, buf, len)` API, which appears to be *roughly* equivalent to Linux's `TCP_INFO`. Unfortunately there's no Golang binding for it in `golang.org/x/sys/unix` though.