### PR TITLE
[Bugfix] Global adherence to max concurrent streams

### DIFF
--- a/utilities/transport.go
+++ b/utilities/transport.go
@@ -41,6 +41,9 @@ func OverrideHostTransport(transport *http.Transport, connectToAddr string) {
 		return dialer.DialContext(ctx, network, addr)
 	}
 
-	http2.ConfigureTransport(transport)
-
+	if t2, err := http2.ConfigureTransports(transport); err != nil {
+		panic("Panic: Could not properly upgrade an http/1.1 transport for http/2.")
+	} else {
+		t2.StrictMaxConcurrentStreams = true
+	}
 }


### PR DESCRIPTION
If a connection in a connection pool is asked for an additional stream that puts it over the limit of the max concurrent connections, the connection pool will spawn a new connection. This behavior is not what we want -- we would prefer that the new connection just wait its turn. Setting the `http2/Transport.StrictMaxConcurrentStreams` flag will accomplish that.