### PR TITLE
[Feature] Add detailed final RPM output

### DIFF
--- a/networkQuality.go
+++ b/networkQuality.go
@@ -1132,11 +1132,6 @@ func main() {
 					selfRttsQualityAttenuation.GetGamingQoO()), 1, "\t")
 			}
 
-			if *detailedCliFlag {
-				direction.FormattedResults += utilities.IndentOutput("RPM Calculation stats:\n", 1, "\t")
-				direction.FormattedResults += utilities.IndentOutput(directionResult.ToString(), 2, "\t")
-			}
-
 			direction.FormattedResults += utilities.IndentOutput(fmt.Sprintf(
 				"RPM: %.0f (P%d)\n", directionResult.PNRpm, specParameters.Percentile), 1, "\t")
 			direction.FormattedResults += utilities.IndentOutput(fmt.Sprintf(

--- a/networkQuality.go
+++ b/networkQuality.go
@@ -1082,7 +1082,7 @@ func main() {
 			for _, label := range []string{"Unbounded ", ""} {
 				directionResult = rpm.CalculateRpm(direction.SelfRtts, direction.ForeignRtts,
 					specParameters.TrimmedMeanPct, specParameters.Percentile)
-				if *debugCliFlag {
+				if *debugCliFlag || *detailedCliFlag {
 					direction.FormattedResults += utilities.IndentOutput(
 						fmt.Sprintf("%vRPM Calculation Statistics:\n", label), 1, "\t")
 					direction.FormattedResults += utilities.IndentOutput(directionResult.ToString(), 2, "\t")
@@ -1229,7 +1229,7 @@ func main() {
 		fmt.Printf("========\n")
 	}
 
-	if *debugCliFlag {
+	if *detailedCliFlag || *debugCliFlag {
 		unboundedAllSelfRtts := series.NewWindowSeries[float64, uint64](series.Forever, 0)
 		unboundedAllForeignRtts := series.NewWindowSeries[float64, uint64](series.Forever, 0)
 
@@ -1241,7 +1241,8 @@ func main() {
 		result := rpm.CalculateRpm(unboundedAllSelfRtts, unboundedAllForeignRtts,
 			specParameters.TrimmedMeanPct, specParameters.Percentile)
 
-		fmt.Printf("Unbounded Final RPM Calculation stats:\n%v\n", result.ToString())
+		fmt.Printf("Unbounded Final RPM Calculation stats:\n%v\n",
+			utilities.IndentOutput(result.ToString(), 1, "\t"))
 
 		fmt.Printf("Unbounded Final RPM: %.0f (P%d)\n", result.PNRpm, specParameters.Percentile)
 		fmt.Printf("Unbounded Final RPM: %.0f (Single-Sided %v%% Trimmed Mean)\n",
@@ -1284,7 +1285,7 @@ func main() {
 		result.MeanRpm, specParameters.TrimmedMeanPct,
 		utilities.Conditional(*detailedCliFlag, fmt.Sprintf("RTT: %.6fs", result.ProbeRttMean), ""))
 
-	if *detailedCliFlag {
+	if *detailedCliFlag || *debugCliFlag {
 		fmt.Printf("Final RPM (Self Only): %.0f (P%d) RTT: %.6fs\n", result.SelfPNRpm,
 			specParameters.Percentile, result.SelfProbeRttPN)
 		fmt.Printf("Final RPM (Self Only): %.0f (Single-Sided %v%% Trimmed Mean) RTT: %.6fs\n",

--- a/networkQuality.go
+++ b/networkQuality.go
@@ -1132,6 +1132,11 @@ func main() {
 					selfRttsQualityAttenuation.GetGamingQoO()), 1, "\t")
 			}
 
+			if *detailedCliFlag {
+				direction.FormattedResults += utilities.IndentOutput("RPM Calculation stats:\n", 1, "\t")
+				direction.FormattedResults += utilities.IndentOutput(directionResult.ToString(), 2, "\t")
+			}
+
 			direction.FormattedResults += utilities.IndentOutput(fmt.Sprintf(
 				"RPM: %.0f (P%d)\n", directionResult.PNRpm, specParameters.Percentile), 1, "\t")
 			direction.FormattedResults += utilities.IndentOutput(fmt.Sprintf(
@@ -1273,18 +1278,22 @@ func main() {
 			utilities.IndentOutput(result.ToString(), 1, "\t"))
 	}
 
-	fmt.Printf("Final RPM: %.0f (P%d)\n", result.PNRpm, specParameters.Percentile)
-	fmt.Printf("Final RPM: %.0f (Single-Sided %v%% Trimmed Mean)\n",
-		result.MeanRpm, specParameters.TrimmedMeanPct)
+	fmt.Printf("Final RPM: %.0f (P%d) %s\n", result.PNRpm, specParameters.Percentile,
+		utilities.Conditional(*detailedCliFlag, fmt.Sprintf("RTT: %.6fs", result.ProbeRttPN), ""))
+	fmt.Printf("Final RPM: %.0f (Single-Sided %v%% Trimmed Mean) %s\n",
+		result.MeanRpm, specParameters.TrimmedMeanPct,
+		utilities.Conditional(*detailedCliFlag, fmt.Sprintf("RTT: %.6fs", result.ProbeRttMean), ""))
 
 	if *detailedCliFlag {
-		fmt.Printf("Final RPM (Self Only): %.0f (P%d)\n", result.SelfPNRpm, specParameters.Percentile)
-		fmt.Printf("Final RPM (Self Only): %.0f (Single-Sided %v%% Trimmed Mean)\n",
-			result.SelfMeanRpm, specParameters.TrimmedMeanPct)
+		fmt.Printf("Final RPM (Self Only): %.0f (P%d) RTT: %.6fs\n", result.SelfPNRpm,
+			specParameters.Percentile, result.SelfProbeRttPN)
+		fmt.Printf("Final RPM (Self Only): %.0f (Single-Sided %v%% Trimmed Mean) RTT: %.6fs\n",
+			result.SelfMeanRpm, specParameters.TrimmedMeanPct, result.SelfProbeRttMean)
 
-		fmt.Printf("Final RPM (Foreign Only): %.0f (P%d)\n", result.ForeignPNRpm, specParameters.Percentile)
-		fmt.Printf("Final RPM (Foreign Only): %.0f (Single-Sided %v%% Trimmed Mean)\n",
-			result.ForeignMeanRpm, specParameters.TrimmedMeanPct)
+		fmt.Printf("Final RPM (Foreign Only): %.0f (P%d) RTT: %.6fs\n", result.ForeignPNRpm,
+			specParameters.Percentile, result.ForeignProbeRttPN)
+		fmt.Printf("Final RPM (Foreign Only): %.0f (Single-Sided %v%% Trimmed Mean) RTT: %.6fs\n",
+			result.ForeignMeanRpm, specParameters.TrimmedMeanPct, result.ForeignProbeRttMean)
 	}
 
 	if *calculateRelativeRpm {

--- a/networkQuality.go
+++ b/networkQuality.go
@@ -70,6 +70,11 @@ var (
 		constants.DefaultDebug,
 		"Enable debugging.",
 	)
+	detailedCliFlag = flag.Bool(
+		"detailed",
+		constants.DefaultDebug,
+		"Enable detailed result output.",
+	)
 	rpmtimeout = flag.Int(
 		"rpm.timeout",
 		constants.DefaultTestTime,
@@ -1263,13 +1268,24 @@ func main() {
 	result := rpm.CalculateRpm(boundedAllSelfRtts, boundedAllForeignRtts,
 		specParameters.TrimmedMeanPct, specParameters.Percentile)
 
-	if *debugCliFlag {
-		fmt.Printf("Final RPM Calculation stats:\n%v\n", result.ToString())
+	if *debugCliFlag || *detailedCliFlag {
+		fmt.Printf("Final RPM Calculation stats:\n%v\n",
+			utilities.IndentOutput(result.ToString(), 1, "\t"))
 	}
 
 	fmt.Printf("Final RPM: %.0f (P%d)\n", result.PNRpm, specParameters.Percentile)
 	fmt.Printf("Final RPM: %.0f (Single-Sided %v%% Trimmed Mean)\n",
 		result.MeanRpm, specParameters.TrimmedMeanPct)
+
+	if *detailedCliFlag {
+		fmt.Printf("Final RPM (Self Only): %.0f (P%d)\n", result.SelfPNRpm, specParameters.Percentile)
+		fmt.Printf("Final RPM (Self Only): %.0f (Single-Sided %v%% Trimmed Mean)\n",
+			result.SelfMeanRpm, specParameters.TrimmedMeanPct)
+
+		fmt.Printf("Final RPM (Foreign Only): %.0f (P%d)\n", result.ForeignPNRpm, specParameters.Percentile)
+		fmt.Printf("Final RPM (Foreign Only): %.0f (Single-Sided %v%% Trimmed Mean)\n",
+			result.ForeignMeanRpm, specParameters.TrimmedMeanPct)
+	}
 
 	if *calculateRelativeRpm {
 		if baselineRpm == nil {

--- a/rpm/calculations.go
+++ b/rpm/calculations.go
@@ -32,6 +32,10 @@ type Rpm[Data utilities.Number] struct {
 	ForeignProbeRttMean float64
 	PNRpm               float64
 	MeanRpm             float64
+	SelfPNRpm           float64
+	SelfMeanRpm         float64
+	ForeignPNRpm        float64
+	ForeignMeanRpm      float64
 }
 
 func CalculateRpm[Data utilities.Number, Bucket utilities.Number](
@@ -83,12 +87,20 @@ func CalculateRpm[Data utilities.Number, Bucket utilities.Number](
 	pnRpm := 60.0 / (float64(selfProbeRoundTripTimePN+foreignProbeRoundTripTimePN) / 2.0)
 	meanRpm := 60.0 / (float64(selfProbeRoundTripTimeMean+foreignProbeRoundTripTimeMean) / 2.0)
 
+	selfPnRpm := 60.0 / (float64(selfProbeRoundTripTimePN))
+	selfMeanRpm := 60.0 / (float64(selfProbeRoundTripTimeMean))
+
+	foreignPnRpm := 60.0 / (float64(foreignProbeRoundTripTimePN))
+	foreignMeanRpm := 60.0 / (float64(foreignProbeRoundTripTimeMean))
+
 	return &Rpm[Data]{
 		SelfRttsTotal: selfRttsTotalCount, ForeignRttsTotal: foreignRttsTotalCount,
 		SelfRttsTrimmed: selfRttsTrimmedCount, ForeignRttsTrimmed: foreignRttsTrimmedCount,
 		SelfProbeRttPN: selfProbeRoundTripTimePN, ForeignProbeRttPN: foreignProbeRoundTripTimePN,
 		SelfProbeRttMean: selfProbeRoundTripTimeMean, ForeignProbeRttMean: foreignProbeRoundTripTimeMean,
 		PNRpm: pnRpm, MeanRpm: meanRpm,
+		ForeignPNRpm: foreignPnRpm, ForeignMeanRpm: foreignMeanRpm,
+		SelfPNRpm: selfPnRpm, SelfMeanRpm: selfMeanRpm,
 	}
 }
 

--- a/rpm/calculations.go
+++ b/rpm/calculations.go
@@ -30,6 +30,8 @@ type Rpm[Data utilities.Number] struct {
 	ForeignProbeRttPN   Data
 	SelfProbeRttMean    float64
 	ForeignProbeRttMean float64
+	ProbeRttPN          float64
+	ProbeRttMean        float64
 	PNRpm               float64
 	MeanRpm             float64
 	SelfPNRpm           float64
@@ -65,9 +67,9 @@ func CalculateRpm[Data utilities.Number, Bucket utilities.Number](
 	selfRttsTotalCount, _ := boundedSelfRtts.Count()
 	foreignRttsTotalCount, _ := foreignRtts.Count()
 
-	_, selfProbeRoundTripTimeMean, selfRttsTrimmed :=
+	_, selfProbeRoundTripTimeTrimmedMean, selfRttsTrimmed :=
 		series.TrimmedMean(boundedSelfRtts, int(trimming))
-	_, foreignProbeRoundTripTimeMean, foreignRttsTrimmed :=
+	_, foreignProbeRoundTripTimeTrimmedMean, foreignRttsTrimmed :=
 		series.TrimmedMean(foreignRtts, int(trimming))
 
 	selfRttsTrimmedCount := len(selfRttsTrimmed)
@@ -83,24 +85,37 @@ func CalculateRpm[Data utilities.Number, Bucket utilities.Number](
 	// of the tcp, tls and http connections, respectively. However, we cannot break out
 	// the individual RTTs so we assume that they are roughly equal.
 
+	probeRoundTripTimePN := (float64(selfProbeRoundTripTimePN+foreignProbeRoundTripTimePN) / 2.0)
+	probeRoundTripTimeTrimmedMean := (float64(selfProbeRoundTripTimeTrimmedMean+
+		foreignProbeRoundTripTimeTrimmedMean) / 2.0)
+
 	// This is 60 because we measure in seconds not ms
-	pnRpm := 60.0 / (float64(selfProbeRoundTripTimePN+foreignProbeRoundTripTimePN) / 2.0)
-	meanRpm := 60.0 / (float64(selfProbeRoundTripTimeMean+foreignProbeRoundTripTimeMean) / 2.0)
+	pnRpm := 60.0 / probeRoundTripTimePN
+	meanRpm := 60.0 / probeRoundTripTimeTrimmedMean
 
 	selfPnRpm := 60.0 / (float64(selfProbeRoundTripTimePN))
-	selfMeanRpm := 60.0 / (float64(selfProbeRoundTripTimeMean))
+	selfMeanRpm := 60.0 / (float64(selfProbeRoundTripTimeTrimmedMean))
 
 	foreignPnRpm := 60.0 / (float64(foreignProbeRoundTripTimePN))
-	foreignMeanRpm := 60.0 / (float64(foreignProbeRoundTripTimeMean))
+	foreignMeanRpm := 60.0 / (float64(foreignProbeRoundTripTimeTrimmedMean))
 
 	return &Rpm[Data]{
-		SelfRttsTotal: selfRttsTotalCount, ForeignRttsTotal: foreignRttsTotalCount,
-		SelfRttsTrimmed: selfRttsTrimmedCount, ForeignRttsTrimmed: foreignRttsTrimmedCount,
-		SelfProbeRttPN: selfProbeRoundTripTimePN, ForeignProbeRttPN: foreignProbeRoundTripTimePN,
-		SelfProbeRttMean: selfProbeRoundTripTimeMean, ForeignProbeRttMean: foreignProbeRoundTripTimeMean,
-		PNRpm: pnRpm, MeanRpm: meanRpm,
-		ForeignPNRpm: foreignPnRpm, ForeignMeanRpm: foreignMeanRpm,
-		SelfPNRpm: selfPnRpm, SelfMeanRpm: selfMeanRpm,
+		SelfRttsTotal:       selfRttsTotalCount,
+		ForeignRttsTotal:    foreignRttsTotalCount,
+		SelfRttsTrimmed:     selfRttsTrimmedCount,
+		ForeignRttsTrimmed:  foreignRttsTrimmedCount,
+		SelfProbeRttPN:      selfProbeRoundTripTimePN,
+		ForeignProbeRttPN:   foreignProbeRoundTripTimePN,
+		SelfProbeRttMean:    selfProbeRoundTripTimeTrimmedMean,
+		ForeignProbeRttMean: foreignProbeRoundTripTimeTrimmedMean,
+		ProbeRttPN:          probeRoundTripTimePN,
+		ProbeRttMean:        probeRoundTripTimeTrimmedMean,
+		PNRpm:               pnRpm,
+		MeanRpm:             meanRpm,
+		ForeignPNRpm:        foreignPnRpm,
+		ForeignMeanRpm:      foreignMeanRpm,
+		SelfPNRpm:           selfPnRpm,
+		SelfMeanRpm:         selfMeanRpm,
 	}
 }
 
@@ -110,18 +125,22 @@ func (rpm *Rpm[Data]) ToString() string {
 Total Foreign Probes:         %d
 Trimmed Self Probes Count:    %d
 Trimmed Foreign Probes Count: %d
-P90 Self RTT:                 %v
-P90 Foreign RTT:              %v
-Trimmed Mean Self RTT:        %f
-Trimmed Mean Foreign RTT:     %f
+P90 Self RTT:                 %.6fs
+P90 Foreign RTT:              %.6fs
+P90 RTT:                      %.6fs
+Trimmed Mean Self RTT:        %.6fs
+Trimmed Mean Foreign RTT:     %.6fs
+Trimmed Mean RTT:             %.6fs
 `,
 		rpm.SelfRttsTotal,
 		rpm.ForeignRttsTotal,
 		rpm.SelfRttsTrimmed,
 		rpm.ForeignRttsTrimmed,
-		rpm.SelfProbeRttPN,
-		rpm.ForeignProbeRttPN,
-		rpm.SelfProbeRttMean,
-		rpm.ForeignProbeRttMean,
+		float64(rpm.SelfProbeRttPN),
+		float64(rpm.ForeignProbeRttPN),
+		float64(rpm.ProbeRttPN),
+		float64(rpm.SelfProbeRttMean),
+		float64(rpm.ForeignProbeRttMean),
+		float64(rpm.ProbeRttMean),
 	)
 }

--- a/rpm/calculations.go
+++ b/rpm/calculations.go
@@ -123,8 +123,8 @@ func (rpm *Rpm[Data]) ToString() string {
 	return fmt.Sprintf(
 		`Total Self Probes:            %d
 Total Foreign Probes:         %d
-Trimmed Self Probes Count:    %d
-Trimmed Foreign Probes Count: %d
+Trimmed Self Probes Count:    %d of %d
+Trimmed Foreign Probes Count: %d of %d
 P90 Self RTT:                 %.6fs
 P90 Foreign RTT:              %.6fs
 P90 RTT:                      %.6fs
@@ -134,8 +134,8 @@ Trimmed Mean RTT:             %.6fs
 `,
 		rpm.SelfRttsTotal,
 		rpm.ForeignRttsTotal,
-		rpm.SelfRttsTrimmed,
-		rpm.ForeignRttsTrimmed,
+		rpm.SelfRttsTrimmed, rpm.SelfRttsTotal,
+		rpm.ForeignRttsTrimmed, rpm.ForeignRttsTotal,
 		float64(rpm.SelfProbeRttPN),
 		float64(rpm.ForeignProbeRttPN),
 		float64(rpm.ProbeRttPN),


### PR DESCRIPTION
Calculate and display additional RPM information when the user requests with the `--detailed` CLI flag.